### PR TITLE
Update version of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "author": "Ritchie Martori",
   "name": "deployd",


### PR DESCRIPTION
The peer dependency phantomjs@~1.9.1 included from mocha-phantomjs will no longer be automatically installed to fulfill the peerD
ependency in npm 3+. Application will need to depend on it explicitly.
